### PR TITLE
Harden CI workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,6 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-24.04
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
@@ -40,8 +38,8 @@ jobs:
 
       - name: Publish charts
         env:
-          GITHUB_USER: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_USER: 1gtm
+          GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
           CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
         run: |
           ./hack/scripts/publish.sh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
@@ -38,8 +40,8 @@ jobs:
 
       - name: Publish charts
         env:
-          GITHUB_USER: 1gtm
-          GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
         run: |
           ./hack/scripts/publish.sh

--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -17,9 +17,19 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
+      - name: Generate LGTM App token
+        id: lgtm-app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.LGTM_APP_CLIENT_ID }}
+          private-key: ${{ secrets.LGTM_APP_PRIVATE_KEY }}
+          owner: appscode-cloud
+          repositories: CHANGELOG
+          permission-pull-requests: write
+
       - name: Update release tracker
         env:
-          GITHUB_USER: 1gtm
-          GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ steps.lgtm-app-token.outputs.token }}
         run: |
           ./hack/scripts/update-release-tracker.sh


### PR DESCRIPTION
## Summary

Apply the CI hardening pattern from appscode-cloud/installer#1252.

- `release-tracker.yml`: switch to the LGTM GitHub App token (owner `appscode-cloud`, repositories `CHANGELOG`), replacing the legacy `LGTM_GITHUB_TOKEN` PAT.
- `publish.yml`: swap env `GITHUB_USER` / `GITHUB_TOKEN` in `Publish charts` from `1gtm` / `LGTM_GITHUB_TOKEN` to `github.actor` / `GITHUB_TOKEN`; add least-privilege job-level `permissions: contents: write`.
- `ci.yml` and `e2e.yml` were already SHA-pinned and PAT-free.

## Test plan

- [ ] Next merged PR triggers `release-tracker` and the comment lands on the CHANGELOG release tracker.
- [ ] Next push to `master` triggers `publish` and chart publishing still succeeds.